### PR TITLE
BUGFIX: Edit button must be of type button

### DIFF
--- a/js/jquery-comments.js
+++ b/js/jquery-comments.js
@@ -1927,6 +1927,7 @@
                 } else if(!isAttachment && this.options.enableEditing) {
                     var editButton = $('<button/>', {
                         'class': 'action edit',
+                        'type': 'button',
                         text: this.options.textFormatter(this.options.editText)
                     });
                     actions.append(editButton);


### PR DESCRIPTION
If this plugin is placed inside a <form> HTML element, clicking the "edit" button triggers the form to be submitted because the default type for <button> elements is "submit". By changing the edit button to type "button" explicitely, this problem can be solved.