### PR TITLE
Use Font Awesome for close icon, make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you are not using Font Awesome for icons, you should replace the icons with c
 ```javascript
 spinnerIconURL: '',
 noCommentsIconURL: '',
+closeIconURL: '',
 upvoteIconURL: '',		// Only if upvoting is enabled
 replyIconURL: '',		// Only if replying is enabled
 uploadIconURL: '',		// Only if attachments are enabled

--- a/js/jquery-comments.js
+++ b/js/jquery-comments.js
@@ -125,6 +125,7 @@
                 attachmentIconURL: '',
                 fileIconURL: '',
                 noCommentsIconURL: '',
+                closeIconURL: '',
 
                 // Strings to be formatted (for example localization)
                 textareaPlaceholderText: 'Add a comment',
@@ -1330,7 +1331,14 @@
             // Close button
             var closeButton = $('<span/>', {
                 'class': 'close inline-button'
-            }).append($('<span class="left"/>')).append($('<span class="right"/>'));
+            })
+
+            var closeIcon = $('<i class="fa fa-close"/>');
+            if (this.options.closeIconURL.length) {
+                closeIcon.css('background-image', 'url("'+this.options.closeIconURL+'")');
+                closeIcon.addClass('image');
+            }
+            closeButton.append(closeIcon);
 
             // Save button text
             if(existingCommentId) {


### PR DESCRIPTION
I make the close icon replaceable, add _closeIconURL_ to default options.
Also I use Font Awesome icon for the default close icon. Originally the close icon is two crossed spans, a little strange.