### PR TITLE
append to this.$el rather than generic .jquery-comments class

### DIFF
--- a/js/jquery-comments.js
+++ b/js/jquery-comments.js
@@ -224,7 +224,7 @@
             if($.browser.mobile) this.$el.addClass('mobile');
 
             // Init options
-            this.options = $.extend(true, {}, this.getDefaultOptions(), options);;
+            this.options = $.extend(true, {}, this.getDefaultOptions(), options);
 
             // Read-only mode
             if(this.options.readOnly) this.$el.addClass('read-only');
@@ -1559,7 +1559,7 @@
                         return ' ' + tag[0].outerHTML + ' ';
                     },
                 }], {
-                    appendTo: '.jquery-comments',
+                    appendTo: this.$el,
                     dropdownClassName: 'dropdown autocomplete',
                     maxCount: 5,
                     rightEdgeOffset: 0,


### PR DESCRIPTION
I found that there is a small bug when we have multiple instances of jquery-comments on a single page, with both instances depending on the textcomplete plugin. The textcomplete suggestions box will popup on all textareas, not just the one you are focused on. 

![Screenshot 2020-09-24 at 17 16 11](https://user-images.githubusercontent.com/10943310/94172102-fbff2b00-fe89-11ea-8fdc-da341d323d9b.png)

My fix will make it so that we only display on the textarea we are currently focused on.

![Screenshot 2020-09-24 at 17 19 19](https://user-images.githubusercontent.com/10943310/94172228-25b85200-fe8a-11ea-8c4e-e160fa6dd688.png)
